### PR TITLE
Add Row Level Security Policy to courses_likes Table

### DIFF
--- a/supabase/migrations/20250415230506_add_rls_policy_to_cources_likes.sql
+++ b/supabase/migrations/20250415230506_add_rls_policy_to_cources_likes.sql
@@ -1,0 +1,36 @@
+-- Enable Row Level Security on the table
+ALTER TABLE public.courses_likes ENABLE ROW LEVEL SECURITY;
+
+
+
+-- Function to check if the authenticated user owns the record with the given user_id
+CREATE OR REPLACE FUNCTION public.user_owns_record(user_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $function$
+BEGIN
+    RETURN EXISTS (
+        SELECT 1 
+        FROM public.users 
+        WHERE id = user_id 
+        AND auth_user_id = auth.uid()
+        LIMIT 1
+    );
+END;
+$function$;
+
+-- Create a policy allowing users to select only their own liked courses
+CREATE POLICY select_own_liked_courses
+ON public.courses_likes
+FOR SELECT
+TO public
+USING (user_owns_record(user_id));
+
+
+-- Add updated_at column to courses_likes table if missing
+ALTER TABLE public.courses_likes
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT now();
+
+

--- a/supabase/tests/database/courses_likes_rls_policy.test.sql
+++ b/supabase/tests/database/courses_likes_rls_policy.test.sql
@@ -1,0 +1,74 @@
+BEGIN;
+
+SELECT plan( 3 );
+
+SELECT policies_are(
+  'public',
+  'courses_likes',
+  ARRAY [
+    'select_own_liked_courses'
+  ]
+);
+
+
+SELECT gen_random_uuid() AS user1_id \gset
+SELECT gen_random_uuid() AS user1_auth_id \gset
+SELECT gen_random_uuid() AS user2_id \gset
+SELECT gen_random_uuid() AS user2_auth_id \gset
+SELECT gen_random_uuid() AS course1_id \gset
+SELECT gen_random_uuid() AS course2_id \gset
+
+
+-- Insert two auth users
+INSERT INTO auth.users (id) VALUES (:'user1_auth_id');
+INSERT INTO auth.users (id) VALUES (:'user2_auth_id');
+
+
+-- Delete existing public users before insert
+DELETE FROM public.users;
+
+-- Insert two users with auth_user_id
+INSERT INTO public.users (id, auth_user_id, first_name, last_name, created_at, updated_at) 
+VALUES
+    (:'user1_id', :'user1_auth_id', 'User', 'One', now(), now()),
+    (:'user2_id', :'user2_auth_id', 'User', 'Two', now(), now());
+
+
+-- Insert two courses
+INSERT INTO public.courses (id, title, active, cost, created_at, updated_at) 
+VALUES
+    (:'course1_id', 'Course One', true, 99.99, now(), now()),
+    (:'course2_id', 'Course Two', true, 49.99, now(), now());
+
+
+-- Insert course likes with random UUIDs
+INSERT INTO public.courses_likes (user_id, course_id, created_at, updated_at) 
+VALUES
+    (:'user1_id', :'course1_id', now(), now()),
+    (:'user2_id', :'course2_id', now(), now());
+
+-- Set initial role and JWT claim for User 1
+SET LOCAL request.jwt.claim.sub = :'user1_auth_id';
+SET ROLE authenticated;
+
+-- Test: User 1 should see only his own likes
+SELECT results_eq(
+  'SELECT user_id::text, course_id::text FROM public.courses_likes',
+  format('VALUES (%L, %L)', :'user1_id', :'course1_id'),
+  'User 1 should see only his own likes'
+);
+
+
+-- Test: User 2 should see only his own likes
+SET LOCAL request.jwt.claim.sub = :'user2_auth_id';
+set role authenticated;
+
+select results_eq(
+  'SELECT user_id::text, course_id::text FROM public.courses_likes',
+  format('VALUES (%L, %L)', :'user2_id', :'course2_id'),
+  'User 2 should see only his own likes'
+);
+
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Create a migration
```
supabase migration new add_rls_policy_to_courses_likes
```
This will create a new file at: `supabase/migrations/20250415230506_add_rls_policy_to_cources_likes.sql`
There are 4 SQL queries
- Enable Row Level Security on courses_likes table
- Create `user_owns_record` function to check auth user
- Create a `select_own_liked_courses` Policy
- Add `updated_at` column to `courses_likes` table

## Apply the migration
```
supabase db reset
```
## Create a Test for the Row Level Security
- create a test file at:
```
supabase/tests/database/courses_likes_rls_policy.test.sql
```

## Run the Test
```
supabase db test
```

![image](https://github.com/user-attachments/assets/6ed1a49c-ce70-4fce-839c-b8bcf12e6204)



